### PR TITLE
Build with dylib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## trunk
+
+- Compatibility with bytecode executables. This is achieved by removing the bundled `libpython.a` static library and instead just statically linking it into the binding.
+
 ## 0.1.9 (2022-11-4)
 
 - Bump the bundled CPython version to 3.11.0
@@ -15,12 +19,12 @@
 
 ## 0.1.6 (2021-11-12)
 
-- Expose 2 additional fields `end_lineno` and `end_offset` from CPython3.10 `SyntaxError`. Fix an error in documentation where column numbers should start from 1 instead of 0. 
+- Expose 2 additional fields `end_lineno` and `end_offset` from CPython3.10 `SyntaxError`. Fix an error in documentation where column numbers should start from 1 instead of 0.
 - Remove the optional `filename` argument from the `parse_module` API. It turns out that this argument is actually dropped when computing error messages so it does not serve any purpose at the moment.
 
 ## 0.1.5 (2021-10-8)
 
-- Disable LTO build of CPython in release mode. Turning on LTO turns out to be rather detrimental to link time when building downstream binaries. 
+- Disable LTO build of CPython in release mode. Turning on LTO turns out to be rather detrimental to link time when building downstream binaries.
 
 ## 0.1.4 (2021-10-5)
 

--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,4 @@
 (executable
  (name pyre_parse)
+ (modes byte exe)
  (libraries pyreAst stdio sexplib cmdliner))

--- a/lib/taglessFinal/dune
+++ b/lib/taglessFinal/dune
@@ -9,7 +9,7 @@
 (rule
  (deps
   (source_tree vendor))
- (targets libpython.a pyconfig.h)
+ (targets pyconfig.h libpython.a)
  (action
   (no-infer
    (progn
@@ -19,7 +19,7 @@
       MACOSX_DEPLOYMENT_TARGET
       11.0
       (progn
-       (run ./configure)
+       (run ./configure --enable-shared)
        (run make libpython3.11.a))))
     (copy vendor/libpython3.11.a libpython.a)
     (copy vendor/pyconfig.h pyconfig.h)))))
@@ -28,10 +28,12 @@
  (name taglessFinal)
  (package pyre-ast)
  (libraries base)
- (no_dynlink)
  (foreign_stubs
   (language c)
   (names binding)
   (flags :standard -Ivendor/Include -I.))
- (c_library_flags -lpython -lutil -lpthread)
- (foreign_archives python))
+ (c_library_flags
+  -lpthread
+  -lpython
+  -lutil
+  -L%{project_root}/_build/default/lib/taglessFinal/))


### PR DESCRIPTION
First crack at fixing https://github.com/grievejia/pyre-ast/issues/6

See my comment here for more details: https://github.com/grievejia/pyre-ast/issues/6#issuecomment-1664747782

Before this patch, one could successfully do:

```
dune exec ./bin/pyre_parse.exe
```

but
```
dune exec ./bin/pyre_parse.bc
```
would fail.

Now, both work!